### PR TITLE
Fix byte_validator to check for base64 validity

### DIFF
--- a/aiogoogle/validate.py
+++ b/aiogoogle/validate.py
@@ -22,6 +22,7 @@ __all__ = [
     'validate',
 ]
 
+import base64
 import datetime
 import warnings
 import re
@@ -164,8 +165,7 @@ def float_validator(value, schema_name=None):
 
 @handle_type_and_value_errors
 def byte_validator(value, schema_name=None):
-    if not isinstance(value, bytes):
-        raise ValidationError(make_validation_error(value, 'Bytes type', schema_name))
+    base64.urlsafe_b64decode(value)
 
 @handle_type_and_value_errors
 def date_validator(value, schema_name=None):

--- a/examples/README.md
+++ b/examples/README.md
@@ -214,6 +214,29 @@ API explorer link:
 * https://developers.google.com/apis-explorer/#p/drive/v3/drive.files.create
 * https://developers.google.com/apis-explorer/#p/drive/v3/drive.files.update
 
+### 7. get_email_header.py
+
+What it does:
+
+* Prints the headers for an email returned by the gmail list API
+
+API name and API version required:
+
+* gmail-v1
+
+Scopes Required:
+
+* "https://www.googleapis.com/auth/gmail.readonly"
+
+User Credentials Required:
+
+* yes
+
+API explorer link:
+
+* https://developers.google.com/gmail/api/v1/reference/users/messages/list
+* https://developers.google.com/gmail/api/v1/reference/users/messages/get
+
 ## OAuth2
 
 

--- a/examples/get_email_headers.py
+++ b/examples/get_email_headers.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3.7
+
+import asyncio
+
+from helpers import Aiogoogle, user_creds, client_creds
+
+async def get_email_headers():
+    async with Aiogoogle(user_creds=user_creds, client_creds=client_creds) as google:
+        gmail = await google.discover("gmail", "v1")
+
+        response = await google.as_user(
+            gmail.users.messages.list(userId="me", maxResults=1)
+        )
+        key = response["messages"][0]["id"]
+        email = await google.as_user(gmail.users.messages.get(userId="me", id=key))
+    headers = email["payload"]["headers"]
+    for header in headers:
+        print(f"{header['name']}: {header['value']}")
+
+if __name__ == "__main__":
+    asyncio.run(get_email_headers())


### PR DESCRIPTION
According to https://developers.google.com/discovery/v1/type-format, the "byte" format implies a base64 encoding.  Fixing this allows gmail-v1.users.messages.get requests to pass validation.