### PR TITLE
Get tests running under Python 3.6

### DIFF
--- a/aiogoogle/sessions/aiohttp_session.py
+++ b/aiogoogle/sessions/aiohttp_session.py
@@ -151,11 +151,11 @@ class AiohttpSession(ClientSession, AbstractSession):
         async def schedule_tasks():
             if full_res is True:
                 tasks = [
-                    asyncio.create_task(get_response(request)) for request in requests
+                    asyncio.ensure_future(get_response(request)) for request in requests
                 ]
             else:
                 tasks = [
-                    asyncio.create_task(get_content(request)) for request in requests
+                    asyncio.ensure_future(get_content(request)) for request in requests
                 ]
             return await asyncio.gather(*tasks, return_exceptions=False)
 

--- a/tests/refresh_all_apis.py
+++ b/tests/refresh_all_apis.py
@@ -80,4 +80,4 @@ async def refresh_disc_docs_json():
 
 
 if __name__ == "__main__":
-    asyncio.run(refresh_disc_docs_json())
+    asyncio.get_event_loop().run_until_complete(refresh_disc_docs_json())

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37
+envlist=py36,py37
 
 [testenv]
 deps = 


### PR DESCRIPTION
This library is exactly what I needed to replace google-api-python-client with something async-capable, thanks!

I did notice that only Python 3.7 support is claimed, and errors happen under Python 3.6. It seems like only minor changes are required to support 3.6, based on what was required to get the test suite passing:

* Replace 3.7-only `asyncio.create_task()` with `asyncio.ensure_future()`
* Avoid using `asyncio.run()`, instead using `run_until_complete()`

I've applied those changes only to the library and test code (leaving `examples/` untouched) and added Python 3.6 to the test environments.