### PR TITLE
Add support for backoff

### DIFF
--- a/aiogoogle/client.py
+++ b/aiogoogle/client.py
@@ -1,6 +1,5 @@
 __all__ = ["Aiogoogle"]
 
-
 from .resource import GoogleAPI
 from .auth.managers import Oauth2Manager, ApiKeyManager, OpenIdConnectManager, ServiceAccountManager
 from .sessions.aiohttp_session import AiohttpSession
@@ -44,12 +43,13 @@ class Aiogoogle:
     """
 
     def __init__(
-        self,
-        session_factory=AiohttpSession,
-        api_key=None,
-        user_creds=None,
-        client_creds=None,
-        service_account_creds=None,
+            self,
+            session_factory=AiohttpSession,
+            api_key=None,
+            user_creds=None,
+            client_creds=None,
+            service_account_creds=None,
+            backoff_decorator=lambda x: x
     ):
 
         self.session_factory = session_factory
@@ -75,6 +75,8 @@ class Aiogoogle:
 
         # Discovery service
         self.discovery_service = GoogleAPI(DISCOVERY_SERVICE_V1_DISCOVERY_DOC)
+
+        self.backoff_decorator = backoff_decorator
 
     # -------- Only 2 methods of Discover Service V1 ---------#
 
@@ -221,8 +223,8 @@ class Aiogoogle:
 
         # Refresh credentials
         if (
-            user_creds.get("expires_at") is not None
-            and self.oauth2.is_expired(user_creds) is True
+                user_creds.get("expires_at") is not None
+                and self.oauth2.is_expired(user_creds) is True
         ):
             user_creds = await self.oauth2.refresh(
                 user_creds, client_creds=self.client_creds
@@ -240,7 +242,8 @@ class Aiogoogle:
             *authorized_requests,
             timeout=timeout,
             full_res=full_res,
-            session_factory=self.session_factory
+            session_factory=self.session_factory,
+            backoff_decorator=self.backoff_decorator
         )
 
     async def as_service_account(self, *requests, timeout=None, full_res=False, service_account_creds=None):
@@ -283,7 +286,8 @@ class Aiogoogle:
             *authorized_requests,
             timeout=timeout,
             full_res=full_res,
-            session_factory=self.session_factory
+            session_factory=self.session_factory,
+            backoff_decorator=self.backoff_decorator
         )
 
     async def as_api_key(self, *requests, timeout=None, full_res=False, api_key=None):
@@ -325,7 +329,8 @@ class Aiogoogle:
             *authorized_requests,
             timeout=timeout,
             full_res=full_res,
-            session_factory=self.session_factory
+            session_factory=self.session_factory,
+            backoff_decorator=self.backoff_decorator
         )
 
     async def as_anon(self, *requests, timeout=None, full_res=False):
@@ -354,7 +359,8 @@ class Aiogoogle:
             *requests,
             timeout=timeout,
             full_res=full_res,
-            session_factory=self.session_factory
+            session_factory=self.session_factory,
+            backoff_decorator=self.backoff_decorator
         )
 
     async def _ensure_session_set(self):

--- a/aiogoogle/sessions/abc.py
+++ b/aiogoogle/sessions/abc.py
@@ -31,7 +31,7 @@ class AbstractSession(ABC):
         return super(AbstractSession, cls).__new__(cls)
 
     @abstractmethod
-    async def send(self, *requests, timeout=None, full_res=False, session_factory=None):
+    async def send(self, *requests, timeout=None, full_res=False, session_factory=None, backoff_decorator=lambda x:x):
         """
         Takes requests, sends them, returns contents of responses or full http responses.
 

--- a/aiogoogle/sessions/abc.py
+++ b/aiogoogle/sessions/abc.py
@@ -65,7 +65,11 @@ class AbstractSession(ABC):
 
                 * Session factory that creates a session that will handle pagination, resumable uploads etc.
 
-                * Defaults to ``self.__class__`` 
+                * Defaults to ``self.__class__``
+
+            backoff_decorator (function):
+
+                * a decorator to wrap each asynchronous request call in
 
         Returns:
 

--- a/aiogoogle/sessions/aiohttp_session.py
+++ b/aiogoogle/sessions/aiohttp_session.py
@@ -36,6 +36,7 @@ class AiohttpSession(ClientSession, AbstractSession):
         full_res=False,
         raise_for_status=True,
         session_factory=None,
+        backoff_decorator=lambda x: x
     ):
         async def resolve_response(request, response):
             data = None
@@ -78,6 +79,7 @@ class AiohttpSession(ClientSession, AbstractSession):
                 session_factory=session_factory,
             )
 
+        @backoff_decorator
         async def fire_request(request):
             request.headers["Accept-Encoding"] = "gzip"
             request.headers["User-Agent"] = "Aiogoogle Aiohttp (gzip)"

--- a/aiogoogle/sessions/curio_asks_session.py
+++ b/aiogoogle/sessions/curio_asks_session.py
@@ -23,7 +23,8 @@ class CurioAsksSession(Session, AbstractSession):
         timeout=None,
         full_res=False,
         raise_for_status=True,
-        session_factory=None
+        session_factory=None,
+        backoff_decorator=lambda x: x
     ):
         async def resolve_response(request, response):
             data = None
@@ -70,6 +71,7 @@ class CurioAsksSession(Session, AbstractSession):
                 session_factory=session_factory,
             )
 
+        @backoff_decorator
         async def fire_request(request):
             request.headers["Accept-Encoding"] = "gzip"
             request.headers["User-Agent"] = "Aiogoogle Asks Curio (gzip)"

--- a/aiogoogle/sessions/trio_asks_session.py
+++ b/aiogoogle/sessions/trio_asks_session.py
@@ -23,7 +23,8 @@ class TrioAsksSession(Session, AbstractSession):
         timeout=None,
         full_res=False,
         raise_for_status=True,
-        session_factory=None
+        session_factory=None,
+        backoff_decorator=lambda x: x
     ):
         responses = []
 
@@ -72,6 +73,7 @@ class TrioAsksSession(Session, AbstractSession):
                 session_factory=session_factory,
             )
 
+        @backoff_decorator
         async def fire_request(request):
             request.headers["Accept-Encoding"] = "gzip"
             request.headers["User-Agent"] = "Aiogoogle Asks Trio (gzip)"


### PR DESCRIPTION
This PR implements the ability to wrap `fire_request` with a (any) decorator, specifically handy for use with `backoff`. I kind of simply had a go at it, I'm probably missing stuff. Is this something you'ld want to have in the codebase @omarryhan? What do you think about supporting backoff (in any way possible) - I just don't see any good way of doing it ouside of `aiogoogle`