### PR TITLE
Download file in chunks

### DIFF
--- a/aiogoogle/models.py
+++ b/aiogoogle/models.py
@@ -4,6 +4,7 @@ import pprint
 from .excs import HTTPError, AuthError
 
 
+DEFAULT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024
 
 
@@ -88,10 +89,15 @@ class MediaDownload:
 
         file_path (str): Full path of the file to be downloaded
 
+        chunksize (int): Size of a chunk of bytes that a session should write at a time when downloading.
+
     """
 
-    def __init__(self, file_path):
+    def __init__(self, file_path, chunk_size=None):
         self.file_path = file_path
+        if chunk_size is None:
+            chunk_size = DEFAULT_DOWNLOAD_CHUNK_SIZE
+        self.chunk_size = chunk_size
 
 
 class Request:

--- a/aiogoogle/sessions/aiohttp_session.py
+++ b/aiogoogle/sessions/aiohttp_session.py
@@ -48,10 +48,8 @@ class AiohttpSession(ClientSession, AbstractSession):
                 chunk_size = request.media_download.chunk_size
                 download_file = request.media_download.file_path
                 async with aiofiles.open(download_file, "wb+") as f:
-                    chunk = await response.content.read(chunk_size)
-                    while chunk:
-                        await f.write(chunk)
-                        chunk = await response.content.read(chunk_size)
+                    async for line in response.content.iter_chunked(chunk_size):
+                        await f.write(line)
             else:
                 if response.status != 204:  # If no (no content)
                     try:

--- a/aiogoogle/sessions/aiohttp_session.py
+++ b/aiogoogle/sessions/aiohttp_session.py
@@ -45,10 +45,13 @@ class AiohttpSession(ClientSession, AbstractSession):
 
             # If downloading file:
             if request.media_download:
+                chunk_size = request.media_download.chunk_size
                 download_file = request.media_download.file_path
                 async with aiofiles.open(download_file, "wb+") as f:
-                    async for line in response.content:
-                        await f.write(line)
+                    chunk = await response.content.read(chunk_size)
+                    while chunk:
+                        await f.write(chunk)
+                        chunk = await response.content.read(chunk_size)
             else:
                 if response.status != 204:  # If no (no content)
                     try:


### PR DESCRIPTION
Currently, files are downloaded and written to disk one line at a time. This is slow and can fail on binary files without newlines, as the length of a "line" can exceed the maximum buffer size. By downloading in 1 MiB chunks instead, I was able to download a 40 MiB file in 8s instead of 30s.