### PR TITLE
Encode scope when building authorization URI

### DIFF
--- a/aiogoogle/auth/managers.py
+++ b/aiogoogle/auth/managers.py
@@ -406,9 +406,10 @@ class Oauth2Manager:
         scopes = " ".join(scopes or client_creds["scopes"])
         uri = (
             self["authorization_endpoint"]
-            + f'?redirect_uri={client_creds["redirect_uri"]}&scope={scopes}&'
+            + f'?redirect_uri={client_creds["redirect_uri"]}&'
         )
         for param_name, param in {
+            "scope": scopes,
             "client_id": client_creds["client_id"],
             "response_type": response_type,
             "state": state,


### PR DESCRIPTION
## Overview

When we supply multiple scopes, we end up with a space between the
scopes, which isn't a valid URI.

To fix this, we can include the scope param in the list of params to
encode when building the URI.

## Notes

It wasn't clear to me how to get the test suite running locally (some notes in the README would be great for this), so this code should be considered untested.