### PR TITLE
Add option to pass HTTP headers to API calls

### DIFF
--- a/aiogoogle/resource.py
+++ b/aiogoogle/resource.py
@@ -399,6 +399,7 @@ class Method:
         download_file=None,
         pipe_to=None,
         timeout=None,
+        headers=None,
         **uri_params,
     ) -> Request:
         """ 
@@ -431,6 +432,8 @@ class Method:
             download_file (str): full path of file to download to
             
             timeout (str): total timeout for this request
+
+            headers (dict): HTTP headers to send with the HTTP request
             
             **uri_params (dict): path and query, required and optional parameters
 
@@ -608,6 +611,7 @@ class Method:
             data=data,
             json=json,
             timeout=timeout,
+            headers=headers,
             media_download=media_download,
             media_upload=media_upload,
             callback=lambda res: res,  # TODO: get rid of this sorcery.


### PR DESCRIPTION
Suggested implementation for #79.
Tested and working.

Summary:
-----------
Each Google API response has a [E-tag ](https://en.wikipedia.org/wiki/HTTP_ETag) attached to it, which is included in the JSON response.
If you save the response along with this E-tag, you can later check if the content of the response that you previously saved has has changed or not on the server, by adding the "If-None-Match" HTTP header to the API call. If the content has not changed, the API server answers with the code "304 not modifed".

This is a simple way to keep data retrieved from the API up to date.

The code of the API call would look like this:

```python
    async with Aiogoogle(
        api_key= "your-api-key"
    ) as aiogoogle:
        api = await aiogoogle.discover("youtube", "v3")
        # etag hardcoded for the example, but this is supposed to be retrieved from the database or similar:
        etag = "vsu1KWWbOO-15Idit0GDZKgEFfo" 
        result = await aiogoogle.as_api_key( 
            api.videos.list(
                headers={"If-None-Match": etag},
                part="snippet,contentDetails,statistics",
                id="YOUR_VIDEO_ID"
            ),
            full_res=True
        )
        if result.status_code == 304:
            print("Resource was not modified since last check")
```