### PR TITLE
Fixed downloading of blob with a slash in the name (GCS)

### DIFF
--- a/aiogoogle/resource.py
+++ b/aiogoogle/resource.py
@@ -627,8 +627,12 @@ class Method:
                 self._validate_url(sorted_required_path_params)
 
             for k, v in sorted_required_path_params.items():
-                sorted_required_path_params[k] = quote(str(v))
-
+                # Default quoting fails for buckets with a slash in a blob name for storage API:
+                # https://cloud.google.com/storage/docs/request-endpoints#encoding
+                # The following ad-hoc hack forces quoting of slash in "object" parameter while
+                # keeping it unquoted everywhere else.
+                safe_chars="" if k == "object" else "/"
+                sorted_required_path_params[k] = quote(str(v), safe=safe_chars)
             # Build full path
             # replace named placeholders with empty ones. e.g. {param} --> {}
             # Why? Because some endpoints have different names in their url path placeholders than in their parameter defenitions


### PR DESCRIPTION
Hello, I would like to propose a simple hack/fix for downloading from google cloud storage with a slash in blob name. Some info about blob name encoding can be found [here](https://cloud.google.com/storage/docs/request-endpoints#encoding)

My minimal working example:
```python
import asyncio
import json
from pathlib import Path
from pprint import pprint

from aiogoogle import Aiogoogle
from aiogoogle.auth.creds import ServiceAccountCreds

service_account_key = json.load(open('/home/david/.creds/gsc_key.json'))

creds = ServiceAccountCreds(scopes=[
    "https://www.googleapis.com/auth/devstorage.read_only",
    "https://www.googleapis.com/auth/devstorage.read_write",
    "https://www.googleapis.com/auth/devstorage.full_control",
    "https://www.googleapis.com/auth/cloud-platform.read-only",
    "https://www.googleapis.com/auth/cloud-platform",
],
                            **service_account_key)

TEST_BUCKET = "my-bucket-name"

async def download_storage_bucket(bucket=TEST_BUCKET):
    async with Aiogoogle(service_account_creds=creds) as aiogoogle:
        storage = await aiogoogle.discover("storage", "v1")
        reqs = [
            storage.objects.get(bucket=bucket,
                                object=name,
                                download_file=Path("/tmp") /
                                name.strip("src/"))
            for name in [
                "src/file1.grib2",
                "src/file2.grib2"
            ]
        ]
        res = await aiogoogle.as_service_account(*reqs)
        pprint(res)


if __name__ == "__main__":
    #asyncio.run(upload_storage_bucket())
    #asyncio.run(list_storage_bucket())
    asyncio.run(download_storage_bucket())
```
It fixes the following traceback for me:
```
Traceback (most recent call last):
  File "/home/david/projects/windy-sync/test_aiogoogle.py", line 75, in <module>
    asyncio.run(download_storage_bucket())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/david/projects/windy-sync/test_aiogoogle.py", line 68, in download_storage_bucket
    res = await aiogoogle.as_service_account(*reqs)
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/client.py", line 310, in as_service_account
    return await self.send(
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/client.py", line 414, in send
    return await session.send(*args, **kwargs)
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/sessions/aiohttp_session.py", line 185, in send
    results = await schedule_tasks()
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/sessions/aiohttp_session.py", line 177, in schedule_tasks
    return await asyncio.gather(*tasks, return_exceptions=False)
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/sessions/aiohttp_session.py", line 163, in get_content
    response = await get_response(request)
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/sessions/aiohttp_session.py", line 159, in get_response
    response.raise_for_status()
  File "/home/david/.virtualenvs/radar/lib/python3.10/site-packages/aiogoogle/models.py", line 461, in raise_for_status
    raise HTTPError(msg=self.reason, req=self.req, res=self)
aiogoogle.excs.HTTPError: 

Not Found

Request URL:
https://storage.googleapis.com/storage/v1/b/my-bucket-name/o/src/file1.grib2
```