### PR TITLE
Allow empty string in path_params_safe_chars

### DIFF
--- a/aiogoogle/resource.py
+++ b/aiogoogle/resource.py
@@ -630,7 +630,7 @@ class Method:
                 self._validate_url(sorted_required_path_params)
 
             for k, v in sorted_required_path_params.items():
-                if path_params_safe_chars.get(k):
+                if path_params_safe_chars.get(k) is not None:
                     sorted_required_path_params[k] = quote(
                         str(v),
                         safe=path_params_safe_chars[k]


### PR DESCRIPTION
Hi!

In continuation of #96 and #115.

Without this change one cannot pass an empty string as a safe character because then `else` branch is always chosen.

The default value for `safe` argument in urllib at the moment is `'/'`, but this is not what I want when working with ranges in for example [`spreadsheets.values.get`](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get) method: if there is a sheet with a forward slash in its name (`sheet/with/slash`), the url is currently built like this `https://sheets.googleapis.com/v4/spreadsheets/some-spreadsheet-id/values/sheet/with/slash%21R0C0%3AR3C3` which is clearly wrong and results in 404 from the Google API (should be `.../values/sheet%2Fwith%2Fslash%21R0C0%3AR3C3...`).

Although a valid workaround is to use any definitely safe character (like a letter) like this `path_params_safe_chars={'range': 'A'}` , which results in the first branch being executed and quoting slashes properly, but this is a bit counterintuitive.