### PR TITLE
Support for Oauth2 for refreshing tokens while pagination

### DIFF
--- a/aiogoogle/client.py
+++ b/aiogoogle/client.py
@@ -241,16 +241,12 @@ class Aiogoogle:
             raise TypeError("No user credentials were found")
 
         # Refresh credentials
-        if (
-            user_creds.get("expires_at") is None
-            or (user_creds.get("expires_at") and self.oauth2.is_expired(user_creds) is True)
-        ):
-            user_creds = await self.oauth2.refresh(
+        if user_creds.get("expires_at") is None:
+            is_refreshed, user_creds = await self.oauth2.refresh(
                 user_creds, client_creds=self.client_creds
             )
-
             # Set refreshed user_creds if ones were already existing
-            if self.user_creds is not None:
+            if is_refreshed and self.user_creds is not None:
                 self.user_creds = user_creds
 
         authorized_requests = [
@@ -263,7 +259,8 @@ class Aiogoogle:
             full_res=full_res,
             raise_for_status=raise_for_status,
             session_factory=self.session_factory,
-            auth_manager=self.oauth2
+            auth_manager=self.oauth2,
+            user_creds=user_creds
         )
 
     async def as_service_account(

--- a/aiogoogle/models.py
+++ b/aiogoogle/models.py
@@ -3,6 +3,7 @@ from typing import AsyncIterable
 import pprint
 
 from .excs import HTTPError, AuthError, ValidationError
+from .auth.managers import ServiceAccountManager, Oauth2Manager
 
 DEFAULT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024
@@ -280,6 +281,8 @@ class Response:
         session_factory (aiogoogle.sessions.abc.AbstractSession): A callable implementation of aiogoogle's session interface
         
         auth_manager (aiogoogle.auth.managers.ServiceAccountManager): Service account authorization manager.
+
+        user_creds (aiogoogle.auth.creds.UserCreds): user_creds to make an api call with.
     """
 
     def __init__(
@@ -296,7 +299,8 @@ class Response:
         upload_file=None,
         pipe_from=None,
         session_factory=None,
-        auth_manager=None
+        auth_manager=None,
+        user_creds=None
     ):
         if json and data:
             raise TypeError("Pass either json or data, not both.")
@@ -314,6 +318,8 @@ class Response:
         self.pipe_from = pipe_from
         self.session_factory = session_factory
         self.auth_manager = auth_manager
+        # Used for refreshing tokens for the Oauth2 authentication workflow.
+        self.user_creds = user_creds
 
     @staticmethod
     async def _next_page_generator(
@@ -342,8 +348,16 @@ class Response:
             )
             if next_req is not None:
                 async with session_factory() as sess:
-                    await prev_res.auth_manager.refresh()
-                    prev_res.auth_manager.authorize(next_req)    
+                    if isinstance(prev_res.auth_manager, (ServiceAccountManager, Oauth2Manager)):
+                        authorize_params = [next_req]
+                        if isinstance(prev_res.auth_manager, ServiceAccountManager):
+                            is_refreshed = await prev_res.auth_manager.refresh()
+                        else:
+                            is_refreshed, user_creds = await prev_res.auth_manager.refresh(prev_res.user_creds)
+                            authorize_params.append(user_creds)
+                        
+                        if is_refreshed is True:
+                            prev_res.auth_manager.authorize(*authorize_params)   
                     prev_res = await sess.send(next_req, full_res=True, auth_manager=prev_res.auth_manager)
             else:
                 prev_res = None

--- a/aiogoogle/models.py
+++ b/aiogoogle/models.py
@@ -3,7 +3,6 @@ from typing import AsyncIterable
 import pprint
 
 from .excs import HTTPError, AuthError, ValidationError
-from .auth.managers import ServiceAccountManager, Oauth2Manager
 
 DEFAULT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024
@@ -329,6 +328,7 @@ class Response:
         res_token_name=None,
         json_req=False,
     ):
+        from .auth.managers import ServiceAccountManager, Oauth2Manager
         prev_url = None
         while prev_res is not None:
 

--- a/aiogoogle/sessions/aiohttp_session.py
+++ b/aiogoogle/sessions/aiohttp_session.py
@@ -40,7 +40,8 @@ class AiohttpSession(ClientSession, AbstractSession):
         full_res=False,
         raise_for_status=True,
         session_factory=None,
-        auth_manager=None
+        auth_manager=None,
+        **kwargs
     ):
         async def resolve_response(request, response):
             data = None
@@ -93,7 +94,8 @@ class AiohttpSession(ClientSession, AbstractSession):
                 upload_file=upload_file,
                 pipe_from=pipe_from,
                 session_factory=session_factory,
-                auth_manager=auth_manager
+                auth_manager=auth_manager,
+                user_creds=kwargs.get("user_creds")
             )
 
         async def fire_request(request):


### PR DESCRIPTION
## closes #109 
This PR adds support for auto-refreshing tokens for long-running single API calls for the Oauth2 Authorization flow.
