### PR TITLE
Improve authentication scripts

### DIFF
--- a/examples/auth/openid_connect_cli.py
+++ b/examples/auth/openid_connect_cli.py
@@ -13,6 +13,7 @@ try:
     import yaml
 except:  # noqa: E722  bare-except
     print('couldn\'t import yaml. Install "pyyaml" first')
+    sys.exit(-1)
 
 sys.path.append("../..")
 


### PR DESCRIPTION
This PR improves the authentication scripts by doing two things:
- Refactor the scripts to use `aiohttp.web` instead of `sanic`. `sanic` is not a required package for `aiogoogle` as a whole while `aiohttp` is, so this makes it a bit more convenient for people to use these scripts.
  - That being said, `pyyaml` is still required despite it not being required for `aiogoogle`. Maybe consider using JSON files instead?
- Make the scripts immediately exit out if `pyyaml` isn't detected.