### PR TITLE
chore: add py.typed

### DIFF
--- a/aiogoogle/py.typed
+++ b/aiogoogle/py.typed
@@ -1,0 +1,1 @@
+# typing marker - this file is used by MyPy and other tools to determine that this library is typed

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     tests_require=test_requirements,
     url=main_ns["__url__"],
     packages=find_packages(exclude=['tests*']),
+    package_data={"aiogoogle": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This PR adds a `py.typed` to fix issues raised by MyPy:

<img width="799" alt="Screenshot 2024-05-17 at 12 00 02" src="https://github.com/omarryhan/aiogoogle/assets/30733348/09d55fc7-f81f-4370-80c2-107b929696d8">
