### PR TITLE
fix mypy error on comment '# type:` fixes #143

### DIFF
--- a/aiogoogle/resource.py
+++ b/aiogoogle/resource.py
@@ -35,7 +35,7 @@ STACK_QUERY_PARAMETER_DEFAULT_VALUE = {"type": "string", "location": "query"}
 MEDIA_SIZE_BIT_SHIFTS = {"KB": 10, "MB": 20, "GB": 30, "TB": 40}
 
 # TODO: etagRequired: {
-#    type: "boolean",  # noqa: F821 (weird error)
+#    should be type: "boolean",  # noqa: F821 (weird error)
 #    description: "Whether this method requires an ETag to be specified. The ETag is sent as an HTTP If-Match or If-None-Match header."
 #    }
 # NOTE: etagRequired is only mentioned once in all of the discovery documents available from Google. (In discovery_service-v1. So, it isn't actually being used)


### PR DESCRIPTION
# Changelog
- Reword comment so that it doesn't trigger mypy

## Context
mypy looks through comments to find `# type: ...` comments for type information. `type: "boolean"` is not valid mypy comment so this errors.

fixes #143 