### PR TITLE
Fix two DeprecationWarnings

### DIFF
--- a/aiogoogle/sessions/aiohttp_session.py
+++ b/aiogoogle/sessions/aiohttp_session.py
@@ -125,7 +125,7 @@ class AiohttpSession(ClientSession, AbstractSession):
                             headers=request.headers,
                             data=mpwriter,
                             timeout=request.timeout,
-                            verify_ssl=request._verify_ssl,
+                            ssl=request._verify_ssl,
                         )
                 # Else load file to memory and send
                 else:
@@ -139,7 +139,7 @@ class AiohttpSession(ClientSession, AbstractSession):
                         data=read_file,
                         json=request.json,
                         timeout=request.timeout,
-                        verify_ssl=request._verify_ssl,
+                        ssl=request._verify_ssl,
                     )
             # Else, if no file upload
             else:
@@ -150,7 +150,7 @@ class AiohttpSession(ClientSession, AbstractSession):
                     data=request.data,
                     json=request.json,
                     timeout=request.timeout,
-                    verify_ssl=request._verify_ssl,
+                    ssl=request._verify_ssl,
                 )
 
         # ----------------- send sequence ------------------#

--- a/tests/refresh_all_apis.py
+++ b/tests/refresh_all_apis.py
@@ -60,4 +60,4 @@ async def refresh_disc_docs_json():
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(refresh_disc_docs_json())
+    asyncio.run(refresh_disc_docs_json())


### PR DESCRIPTION
* `verify_ssl` is deprecated in favor of `ssl` since aiohttp 3.0
* `get_event_loop`'s behavior of creating an event loop if there isn't one running is deprecated in Python 3.12