### PR TITLE
fix "aiogoole" typo in docs

### DIFF
--- a/aiogoogle/resource.py
+++ b/aiogoogle/resource.py
@@ -418,7 +418,7 @@ class Method:
 
         Arguments:
 
-            validate (bool): Overrides :param: aiogoogle.Aiogoole.validate if not None
+            validate (bool): Overrides :param: aiogoogle.Aiogoogle.validate if not None
 
             json (dict): Json body
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -825,7 +825,7 @@ Send As User
 .. code-block:: python
 
     import asyncio
-    from aiogoogle import Aiogoole
+    from aiogoogle import Aiogoogle
     from pprint import pprint
 
     async def get_calendar_events():


### PR DESCRIPTION
Thanks for maintaining this repo! :)

This PR fixes a typo "Aiogoole" in some places in the docs, which I discovered when copy and pasting examples from the docs which failed to import.