### PR TITLE
Replace unmaintained tonyg-rfc3339 with stdlib datetime parsing

### DIFF
--- a/aiogoogle/validate.py
+++ b/aiogoogle/validate.py
@@ -24,7 +24,6 @@ import base64
 import datetime
 import warnings
 import re
-import rfc3339
 from functools import wraps
 
 from .excs import ValidationError
@@ -235,6 +234,13 @@ def byte_validator(value, schema_name=None):
     base64.urlsafe_b64decode(value)
 
 
+def parse_rfc3339_datetime(value):
+    # datetime.fromisoformat() rejects the RFC 3339 'Z'/'z' UTC suffix before Python 3.11
+    return datetime.datetime.fromisoformat(
+        value.replace("Z", "+00:00").replace("z", "+00:00")
+    )
+
+
 @handle_type_and_value_errors
 def date_validator(value, schema_name=None):
     msg = make_validation_error_msg(
@@ -243,8 +249,7 @@ def date_validator(value, schema_name=None):
         schema_name,
     )
     try:
-        pvalue = rfc3339.parse_date(value)
-        # pvalue = datetime.date.fromisoformat(value)
+        pvalue = datetime.date.fromisoformat(value)
     except Exception as e:
         raise ValidationError(str(e) + msg)
     if not isinstance(pvalue, datetime.date):
@@ -259,8 +264,7 @@ def datetime_validator(value, schema_name=None):
         schema_name,
     )
     try:
-        pvalue = rfc3339.parse_datetime(value)
-        # pvalue = datetime.datetime.fromisoformat(value)
+        pvalue = parse_rfc3339_datetime(value)
     except Exception as e:
         raise ValidationError(str(e), msg)
     if not isinstance(pvalue, datetime.datetime):

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -2,7 +2,6 @@ aiohttp
 aiofiles
 google-auth
 sphinxcontrib-asyncio
-tonyg-rfc3339
 async-timeout
 asks
 trio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp
 aiofiles
 google-auth
-tonyg-rfc3339
 async-timeout

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,6 @@ aiohttp
 aiofiles
 google-auth
 sphinxcontrib-asyncio
-tonyg-rfc3339
 async-timeout
 asks
 trio

--- a/tests/test_units/test_validate.py
+++ b/tests/test_units/test_validate.py
@@ -461,3 +461,30 @@ def test_validates_repeated(create_api):
             ranges=[132, 'valid'],  # Only first item is invalid
             validate=True
         )
+
+
+def test_date_validator():
+    from aiogoogle.validate import date_validator
+
+    date_validator("2024-01-31")
+
+    with pytest.raises(ValidationError):
+        date_validator("not-a-date")
+
+    with pytest.raises(ValidationError):
+        date_validator("2024-13-01")
+
+
+def test_datetime_validator():
+    from aiogoogle.validate import datetime_validator
+
+    datetime_validator("2024-01-31T12:34:56")
+    datetime_validator("2024-01-31T12:34:56Z")
+    datetime_validator("2024-01-31T12:34:56.123456Z")
+    datetime_validator("2024-01-31T12:34:56+02:00")
+
+    with pytest.raises(ValidationError):
+        datetime_validator("not-a-datetime")
+
+    with pytest.raises(ValidationError):
+        datetime_validator("2024-01-31T25:00:00Z")


### PR DESCRIPTION
Fixes #169

## Why

`tonyg-rfc3339` is unmaintained — [thesis/python-rfc3339](https://github.com/thesis/python-rfc3339) was archived in 2021 and the original [tonyg/python-rfc3339](https://github.com/tonyg/python-rfc3339) in January 2026. It ships no wheel and no `pyproject.toml`, so once pip 25.3 removes the legacy `setup.py bdist_wheel` build path it will stop installing entirely.

## What

Its only use was `parse_date`/`parse_datetime` in the opt-in request validators in `aiogoogle/validate.py`. Those validators' own error messages already tell users to produce values with `datetime.isoformat()`, so the stdlib `fromisoformat()` is the semantically matching check (it was even already sitting there commented out).

- `date_validator` → `datetime.date.fromisoformat()`
- `datetime_validator` → `datetime.datetime.fromisoformat()` via a small helper that maps the RFC 3339 `Z`/`z` UTC suffix to `+00:00`, since `fromisoformat()` only accepts it natively from Python 3.11
- `tonyg-rfc3339` removed from `requirements.txt`, `test_requirements.txt`, and `docs_requirements.txt`
- New unit tests for both validators, including `Z`-suffixed, fractional-second, and offset datetimes

## Testing

Full unit suite (2939 tests) passes on Python 3.9 — i.e. on the pre-3.11 code path that needs the `Z` shim — in a venv without `tonyg-rfc3339` installed.

Note: pre-3.11 `fromisoformat()` is slightly stricter than full RFC 3339 (no lowercase `t` separator, fractional seconds limited to 3 or 6 digits). Since these validators check user-constructed request payloads rather than Google's responses, that strictness matches the documented contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)