### PR TITLE
Fix CI failures from Google live-API drift

### DIFF
--- a/aiogoogle/auth/data.py
+++ b/aiogoogle/auth/data.py
@@ -248,6 +248,7 @@ OAUTH2_V2_DISCVOCERY_DOC = {
 
 WELLKNOWN_OPENID_CONFIGS = {
     "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+    "authorization_response_iss_parameter_supported": True,
     "claims_supported": [
         "aud",
         "email",

--- a/aiogoogle/validate.py
+++ b/aiogoogle/validate.py
@@ -57,10 +57,16 @@ KNOWN_FORMATS = [
     "google-fieldmask",
     "google-duration",
     "google-datetime",
+    "google.protobuf.Any",
 ]
 
 # After writing a format check for any of those formats, remove the format you wrote the checker for.
-IGNORABLE_FORMATS = ["google-fieldmask", "google-duration", "google-datetime"]
+IGNORABLE_FORMATS = [
+    "google-fieldmask",
+    "google-duration",
+    "google-datetime",
+    "google.protobuf.Any",
+]
 
 TYPE_FORMAT_MAPPING = {
     # Given this type, if None then don't check for additional "format" property in the schema, else, format might be any of the mapped values


### PR DESCRIPTION
CI has been red on every branch since the last master run (December 2025) because of two upstream changes on Google's side, unrelated to any code in flight (e.g. #170). Verified both failures reproduce on unmodified master.

## Changes

1. **`test_latest_openid_configs`** — Google added `authorization_response_iss_parameter_supported` to https://accounts.google.com/.well-known/openid-configuration. Refreshed the checked-in copy in `aiogoogle/auth/data.py` (same maintenance as 5f667e9). That key is the only drift.

2. **`test_schemas_for_unknown_formats_and_types`** — Google's discovery docs now use a `google.protobuf.Any` format (currently in `compute-v1` and `dns-v1`; I scanned all ~400 preferred discovery docs and it's the only new format). Added it to `KNOWN_FORMATS` and `IGNORABLE_FORMATS` in `aiogoogle/validate.py`, matching how the other protobuf formats (`google-fieldmask`, `google-duration`, `google-datetime`) are handled — validation skips it rather than dispatching to a (nonexistent) format validator.

## Testing

Replicated the CI sequence locally on Python 3.9 (`refresh_all_apis.py` then the test suites): **2,937 unit tests and 829 integration tests pass**, including the two that were failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)