### PR TITLE
Preserve discovery HTTP errors

### DIFF
--- a/aiogoogle/client.py
+++ b/aiogoogle/client.py
@@ -209,14 +209,12 @@ class Aiogoogle:
 
         try:
             discovery_document = await self.as_anon(request)
-
-        except Exception as e:
-            if isinstance(e, HTTPError):
-                if not disco_doc_ver:
-                    raise ValueError(
-                        f"Failed to fetch discovery document from v1 of the Google Discovery Service. Consider setting `disco_doc_ver=2` parmeter. Error: {e}."
-                    )
-            raise e
+        except HTTPError as e:
+            if disco_doc_ver is None:
+                e.args = (
+                    f"Failed to fetch discovery document from v1 of the Google Discovery Service. Consider setting `disco_doc_ver=2` parameter. Error: {e}.",
+                )
+            raise
 
         return GoogleAPI(discovery_document, validate)
 

--- a/tests/refresh_all_apis.py
+++ b/tests/refresh_all_apis.py
@@ -35,7 +35,7 @@ async def refresh_disc_docs_json():
 
     # Refresh discovery files in tests/data
     for google_api, (name, version) in zip(all_discovery_documents, all_apis):
-        if isinstance(google_api, (HTTPError, ValueError)):
+        if isinstance(google_api, HTTPError):
             e = google_api
             # filter out the errored api from the final_all_apis
             final_all_apis = [api for api in final_all_apis if api[0] != name]

--- a/tests/test_units/test_client.py
+++ b/tests/test_units/test_client.py
@@ -1,6 +1,7 @@
 import sys
 from unittest.mock import patch
 from aiogoogle.client import Aiogoogle, DISCOVERY_SERVICE_V1_DISCOVERY_DOC
+from aiogoogle.excs import HTTPError
 import pytest
 
 
@@ -36,3 +37,42 @@ async def test_fetch_api_discovery_doc_via_google_discovery_service_v2():
         # Validate that the correct Google endpoint would have been called
         google_api_request = mock_send_unauthorized_requests.await_args[0][0]
         google_api_request.url == expected
+
+
+@pytest.mark.parametrize("disco_doc_ver", [None, 2])
+@pytest.mark.asyncio
+async def test_discover_propagates_http_error(disco_doc_ver):
+    req = object()
+    res = object()
+    error = HTTPError("discovery failed", req=req, res=res)
+
+    async def raise_http_error(request):
+        raise error
+
+    google = Aiogoogle()
+    google.as_anon = raise_http_error
+
+    with pytest.raises(HTTPError) as raised:
+        await google.discover("drive", "v3", disco_doc_ver=disco_doc_ver)
+
+    assert raised.value is error
+    assert raised.value.req is req
+    assert raised.value.res is res
+    assert ("disco_doc_ver=2" in str(raised.value)) is (disco_doc_ver is None)
+
+
+@pytest.mark.asyncio
+async def test_discover_propagates_unrelated_value_error():
+    error = ValueError("unrelated error")
+
+    async def raise_value_error(request):
+        raise error
+
+    google = Aiogoogle()
+    google.as_anon = raise_value_error
+
+    with pytest.raises(ValueError) as raised:
+        await google.discover("drive", "v3")
+
+    assert raised.value is error
+    assert str(raised.value) == "unrelated error"


### PR DESCRIPTION
Keep the original HTTPError when a v1 discovery request fails so
callers can inspect the request and response or retry the failure.
Retain the v2 hint and stop treating unrelated ValueError instances
as discovery failures.

Fixes #172